### PR TITLE
hotfix-remove-rds-resouce

### DIFF
--- a/infra/dev/role.tf
+++ b/infra/dev/role.tf
@@ -36,6 +36,7 @@ resource "aws_iam_policy" "s3_full_access_policy" {
   })
 }
 
+/*
 resource "aws_iam_policy" "rds_full_access_policy" {
   name = "dev-rds-full-access"
   policy = jsonencode({
@@ -55,6 +56,7 @@ resource "aws_iam_policy" "rds_full_access_policy" {
     ]
   })
 }
+*/
 
 resource "aws_iam_policy" "lambda_invoke_policy" {
   name = "dev-lambda-invoke-policy"
@@ -94,10 +96,12 @@ resource "aws_iam_role_policy_attachment" "attach_s3_policy" {
   policy_arn = aws_iam_policy.s3_full_access_policy.arn
 }
 
+/*
 resource "aws_iam_role_policy_attachment" "attach_rds_policy" {
   role       = aws_iam_role.dev_instance_role.name
   policy_arn = aws_iam_policy.rds_full_access_policy.arn
 }
+*/
 
 resource "aws_iam_role_policy_attachment" "attach_lambda_invoke_policy" {
   role       = aws_iam_role.dev_instance_role.name

--- a/infra/dev/storage.tf
+++ b/infra/dev/storage.tf
@@ -6,6 +6,7 @@ resource "aws_s3_bucket" "s3_storage" {
   }
 }
 
+/*
 resource "aws_db_subnet_group" "aurora_subnet" {
   subnet_ids = data.aws_subnets.default_subnets.ids
 }
@@ -48,3 +49,4 @@ resource "aws_security_group" "aurora_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+*/


### PR DESCRIPTION
# Description
비용과 관련하여 토의한 결과 Aurora과 RDS를 사용하지 않기로 결정하여, 관련 리소스를 제거합니다.

# Related Cards
- `DB Aurora ⇒ spark로 변경`